### PR TITLE
Detect bazel coverage by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
           "type": "array",
           "scope": "resource",
           "default": [
+            "_coverage_report.dat",
             "lcov.info",
             "cov.xml",
             "coverage.xml",


### PR DESCRIPTION
Bazel writes coverage data to a file named `_coverage_report.dat`.
Ref: https://bazel.build/configure/coverage#running_coverage

Add `_coverage_report.dat` to the default list of `coverageFileNames` for better interoperability with bazel out-of-the-box.